### PR TITLE
Add back Maven signing extension config

### DIFF
--- a/buildSrc/src/main/kotlin/publish-kotlin-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/publish-kotlin-library.gradle.kts
@@ -84,5 +84,10 @@ subprojects {
                 }
             }
         }
+        if (!System.getenv("DISABLE_SIGNING").toBoolean()) {
+            configure<SigningExtension> {
+                sign(publications["maven"])
+            }
+        }
     }
 }


### PR DESCRIPTION
## Context
Publishing is failing with an error of the form:
```
Execution failed for task ':closeSonatypeStagingRepository'.
> Staging repository is not in desired state [closed]: StagingRepository(id=techfigure-1052, state=open, transitioning=false). It is unexpected. Please checkNexus logs using its web interface - it can be caused by validation rules violation. If not, please report it to https://github.com/gradle-nexus/publish-plugin/issues/ with '--info' logs
```
Nexus/Sonatype logs revealed the aforementioned validation rule violation to be the following:
![image](https://user-images.githubusercontent.com/82118011/202319225-3185558c-8cf8-40fe-bfdb-af3a90784967.png)


The likely cause: [this snippet](https://github.com/FigureTechnologies/asset-classification-libs/blob/51188d37ce74e85753c528a9a13b0a19299a121f/buildSrc/src/main/kotlin/publish-kotlin-library.gradle.kts#L88-L92) was probably copied over from `asset-classification-libs` to this repository's equivalent file, but outright removed in an attempt to get local snapshot publishing to work.

Credit to @hyperschwartz for catching this (and writing the code we've been copying from in the first place...)