### PR TITLE
Change from individual codeowners to GitHub team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jchickanosky @rpatel-figure
+* @FigureTechnologies/validation-oracle


### PR DESCRIPTION
## Context
Consolidating code ownership to use GitHub teams as codeowners and maintainers
