### PR TITLE
Add release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -52,12 +52,13 @@ autolabeler:
       - '/update/i'
 exclude-contributors:
   - 'figure-renovate'
+  - 'figure-renovate[bot]'
 replacers:
   - search: '/\[sc-(\d+)\]/gi'
     replace: '[[sc-$1](https://app.shortcut.com/figure/story/$1)]'
   - search: '/\[ch(\d+)\]/gi'
     replace: '[[sc-$1](https://app.shortcut.com/figure/story/$1)]'
-  - search: '/@figure-renovate$/gim'
+  - search: '/@figure-renovate(\[bot\])?$/gim'
     replace: 'by [Renovate](https://github.com/renovatebot/renovate)'
 template: |
   # Changelog

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -50,11 +50,15 @@ autolabeler:
   - label: 'dependencies'
     title:
       - '/update/i'
+exclude-contributors:
+  - 'figure-renovate'
 replacers:
   - search: '/\[sc-(\d+)\]/gi'
     replace: '[[sc-$1](https://app.shortcut.com/figure/story/$1)]'
   - search: '/\[ch(\d+)\]/gi'
     replace: '[[sc-$1](https://app.shortcut.com/figure/story/$1)]'
+  - search: '/@figure-renovate$/gim'
+    replace: 'by [Renovate](https://github.com/renovatebot/renovate)'
 template: |
   # Changelog
   $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,70 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+  - title: '🛸 Enhancements'
+    labels:
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+  - title: '📦 Dependency Updates'
+    label: 'dependencies'
+  - title: '📖 Documentation'
+    label: 'docs'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+autolabeler:
+  - label: 'enhancement'
+    branch:
+      - '/refactor\/.+/'
+    title:
+      - '/refactor/i'
+  - label: 'feature'
+    title:
+      - '/(add)|(feat)/i'
+  - label: 'fix'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'docs'
+    branch:
+      - '/(documentation)|(docs)\/.+/'
+    title:
+      - '/docs/i'
+  - label: 'dependencies'
+    title:
+      - '/update/i'
+replacers:
+  - search: '/\[sc-(\d+)\]/gi'
+    replace: '[[sc-$1](https://app.shortcut.com/figure/story/$1)]'
+  - search: '/\[ch(\d+)\]/gi'
+    replace: '[[sc-$1](https://app.shortcut.com/figure/story/$1)]'
+template: |
+  # Changelog
+  $CHANGES
+  # Notes
+  ## Compatible Versions
+  - [Provenance vProvenanceVersionHere](https://github.com/provenance-io/provenance/blob/vProvenanceVersionHere/docs/Building.md)
+  - [Smart contract vContractVersionHere](https://github.com/FigureTechnologies/validation-oracle-smart-contract/releases/tag/vContractVersionHere)
+  ## Required Updates
+  The relevant PRs and all work that needs to be done for this release to succeed (like updating dependencies) should be listed here
+  ## Contributors
+  $CONTRIBUTORS
+  ## Other
+  Other notes

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,36 @@
+name: Release Drafter
+
+on:
+  # For creating draft releases
+  push:
+    branches:
+      - main
+  # For autolabeling PRs
+  pull_request:
+    types: [ synchronize, opened, reopened, ready_for_review, converted_to_draft ]
+  # For autolabeling PRs from forks
+  pull_request_target:
+    types: [ synchronize, opened, reopened, ready_for_review ]
+  # For manually running the autolabeler
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    name: Update Release Draft
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          # Allows the auto-labeler to run without adding unmerged PRs to the draft
+          disable-releaser: ${{ github.ref_name != 'main' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Context
Setting up release drafter so this repository can produce nicely organized release notes alongside https://github.com/FigureTechnologies/validation-oracle-smart-contract/
## Changes
- Add release drafter workflow and configuration
## Notes
- The release drafter workflow is expected to fail until it exists in the default branch, `main`